### PR TITLE
Put get_terminal_size() in Try-Catch

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -15,7 +15,10 @@ def date():
   date[-1] = date[-1].split('.')[0]
   return ' '.join(date)
 
-wt, ht = get_terminal_size()
+try:
+  wt, ht = get_terminal_size()
+except:
+  wt, ht = (80, 24)
 
 def check_port_open(__address: tuple,stype):
   try:


### PR DESCRIPTION
Prevent get_terminal_size() from errors while buffering:

________________________

Hia:3 Nice project...

I was testing your script and I noticed something:
Suppose we're about to pipe your script to `grep` , to get only the **open ports**:

```shell
┌──(user㉿dhcppc4)-[~/Desktop/TCP_SP/PortScanner]
└─$ python3 __main__.py --hostname 127.0.0.1 | grep -i open
```
It'll cause following errors:
```python
Traceback (most recent call last):
  File "/home/user/Desktop/TCP_SP/PortScanner/__main__.py", line 18, in <module>
    wt, ht = get_terminal_size()
OSError: [Errno 25] Inappropriate ioctl for device
``` 

Or suppose we're about to pipe the result buffer to a file:
```shell
┌──(user㉿dhcppc4)-[~/Desktop/TCP_SP/PortScanner]
└─$ python3 __main__.py --hostname 127.0.0.1 >> result 
```
Same problem goes here:
```python
Traceback (most recent call last):
  File "/home/user/Desktop/TCP_SP/PortScanner/__main__.py", line 18, in <module>
    wt, ht = get_terminal_size()
OSError: [Errno 25] Inappropriate ioctl for device
```

_______________________

If the terminal is buffered, `get_terminal_size()` will trigger `[Errno 25] Inappropriate ioctl for device` because OS has no way of getting rows and columns of a Simulated Terminal.

So, we put it in **Try-Catch** , and we use **Unix standard terminal size** which is : **80 columns by 24 rows** 

If so:
```shell
┌──(user㉿dhcppc4)-[~/Desktop/TCP_SP/PortScanner]
└─$ python3 __main__.py --hostname 127.0.0.1 | grep -i open
        Port 631                                                   open         
        Port 1716                                                  open         
        Port 33272                                                 open         
        Port 48878                                                 open         
        Port 59068                                                 open         
                                                                                                                                                           
┌──(user㉿dhcppc4)-[~/Desktop/TCP_SP/PortScanner]
└─$ python3 __main__.py --hostname 127.0.0.1 >> result     
                                                                                                                                                           
┌──(user㉿dhcppc4)-[~/Desktop/TCP_SP/PortScanner]
└─$ 
```
